### PR TITLE
optimize stream write operation

### DIFF
--- a/pkg/quic/c/msquic.c
+++ b/pkg/quic/c/msquic.c
@@ -15,7 +15,6 @@
 extern void newConnectionCallback(HQUIC, HQUIC);
 extern void newStreamCallback(HQUIC, HQUIC);
 extern void newReadCallback(HQUIC, HQUIC, uint8_t *data, int64_t len);
-extern void completeWriteCallback(HQUIC, HQUIC);
 extern void closeConnectionCallback(HQUIC);
 extern void closePeerConnectionCallback(HQUIC);
 extern void closeStreamCallback(HQUIC,HQUIC);
@@ -78,7 +77,6 @@ StreamCallback(
 {
     switch (Event->Type) {
     case QUIC_STREAM_EVENT_SEND_COMPLETE:
-		completeWriteCallback(Context, Stream);
 		if  (Event->SEND_COMPLETE.ClientContext) {
 			free(Event->SEND_COMPLETE.ClientContext);
 		}

--- a/pkg/quic/callbacks.go
+++ b/pkg/quic/callbacks.go
@@ -74,26 +74,6 @@ func newReadCallback(c, s C.HQUIC, buffer *C.uint8_t, length C.int64_t) {
 	}
 }
 
-//export completeWriteCallback
-func completeWriteCallback(c, s C.HQUIC) {
-	rawConn, has := connections.Load(c)
-	if !has {
-		return // already closed
-	}
-	rawConn.(MsQuicConn).openStream.Lock()
-	defer rawConn.(MsQuicConn).openStream.Unlock()
-	rawStream, has := rawConn.(MsQuicConn).streams.Load(s)
-	if !has {
-		return // already closed
-
-	}
-	stream := rawStream.(MsQuicStream)
-	select {
-	case stream.writeSignal <- struct{}{}:
-	default:
-	}
-}
-
 //export newStreamCallback
 func newStreamCallback(c, s C.HQUIC) {
 	rawConn, has := connections.Load(c)


### PR DESCRIPTION
This change allow us to reach parity with C code.
Benchmark used:
https://github.com/hliu4atomos/ms-quic-benchmark
Result:
```
Client #1 disconnected, total received 9930.45 MB of data
```